### PR TITLE
Add tmux support for displaying man page in a split pane.

### DIFF
--- a/scripts/c.lua
+++ b/scripts/c.lua
@@ -1,5 +1,6 @@
 
 local cscope = require("cscope")
+local tmux = require("tmux")
 local code = require("dit.code")
 local tab_complete = require("dit.tab_complete")
 local line_commit = require("dit.line_commit")
@@ -44,6 +45,8 @@ function on_ctrl(key)
       line_commit.line_commit()
    elseif key == "_" then
       code.comment_block("//")
+   elseif key == "P" then
+      tmux.man()
    end
 end
 

--- a/scripts/tmux.lua
+++ b/scripts/tmux.lua
@@ -1,0 +1,17 @@
+local tmux = {}
+
+local cmd = require("cmd")
+
+local function get_context()
+   local token, x, y, len = buffer:token()
+   if not token then return end
+   return token
+end
+
+function tmux.man()
+   local token = get_context()
+   if not token then return end
+   cmd.run("tmux splitw man '%s'", token)
+end
+
+return tmux


### PR DESCRIPTION
I run dit inside a tmux pane and want to save a few keystrokes when looking up a man page for a token.
CTRL_P makes tmux split dit pane to top (dit) and bottom (man) and move focus to the bottom for browsing.
Hitting 'q' removes the bottom pane and returns focus back to dit.
If man cannot find the given token, tmux flashes and returns to dit (or it's a no-op).