### PR TITLE
For C, dim comment between #if 0 ... #endif (same as /* */).

### DIFF
--- a/highlight/c.dithlinc
+++ b/highlight/c.dithlinc
@@ -59,6 +59,9 @@ rule , symbol
 rule | symbol
 rule & symbol
 rule ; brightsymbol
+rule TODO veryspecial
+rule XXX veryspecial
+rule FIXME veryspecial
 context /* */ dim
    rule TODO veryspecial
    rule XXX veryspecial
@@ -87,5 +90,10 @@ context #include `$ brightspecial
    /context
    context < > special
    /context
+/context
+context #if`[`s`|`t`]`+0 #endif dim
+   rule TODO veryspecial
+   rule XXX veryspecial
+   rule FIXME veryspecial
 /context
 


### PR DESCRIPTION
Also add highlights for TODO, XXX, FIXME done in #pragma style:
https://gcc.gnu.org/onlinedocs/gcc/Diagnostic-Pragmas.html#Diagnostic-Pragmas
This way gcc/clang yells at users about incomplete work.